### PR TITLE
redtick--save-history does nothing if redtick-history-file is nil

### DIFF
--- a/redtick.el
+++ b/redtick.el
@@ -249,14 +249,15 @@
 
 (defun redtick--save-history ()
   "Adding current-pomodoro info to history file."
-  (let ((history (redtick--load redtick-history-file)))
-    (redtick--save redtick-history-file
-                   (add-to-list 'history
-                                (list redtick--pomodoro-started-at
-                                      redtick-work-interval
-                                      redtick-rest-interval
-                                      redtick--pomodoro-description)
-                                t))))
+  (when redtick-history-file
+    (let ((history (redtick--load redtick-history-file)))
+      (redtick--save redtick-history-file
+                     (add-to-list 'history
+                                  (list redtick--pomodoro-started-at
+                                        redtick-work-interval
+                                        redtick-rest-interval
+                                        redtick--pomodoro-description)
+                                  t)))))
 
 (add-hook 'redtick-after-rest-hook #'redtick--save-history)
 


### PR DESCRIPTION
That means the user who doesn't want to save history can set/customise
redtick-history-file to nil and there will be no error when
redtick-after-rest-hook fires.